### PR TITLE
Update utils.py

### DIFF
--- a/akebono/utils.py
+++ b/akebono/utils.py
@@ -47,7 +47,7 @@ def try_decode_bytes_and_get(bt):
     return None
 
 
-def pd_to_csv(df, path, storage_class=None **kwargs):
+def pd_to_csv(df, path, storage_class=None, **kwargs):
     if settings.storage_type == 'local':
         df.to_csv(path, **kwargs)
     elif settings.storage_type == 'gcs':

--- a/akebono/utils.py
+++ b/akebono/utils.py
@@ -53,7 +53,10 @@ def pd_to_csv(df, path, storage_class=None, **kwargs):
     elif settings.storage_type == 'gcs':
         buf = df.to_csv(None, encoding='utf-8', **kwargs)
         bkt = _get_gcs_bucket(settings.storage_option['bucket_name'])
-        bkt.blob(path, storage_class=storage_class, chunk_size=1048576000).upload_from_string(buf, content_type='text/csv')
+        blb = bkt.blob(path, chunk_size=1048576000)
+        if storage_class is not None:
+            blb.storage_class = storage_class
+        blb.upload_from_string(buf, content_type='text/csv')
     else:
         raise ValueError('invalid storage_type')
 

--- a/akebono/utils.py
+++ b/akebono/utils.py
@@ -47,13 +47,13 @@ def try_decode_bytes_and_get(bt):
     return None
 
 
-def pd_to_csv(df, path, **kwargs):
+def pd_to_csv(df, path, storage_class=None **kwargs):
     if settings.storage_type == 'local':
         df.to_csv(path, **kwargs)
     elif settings.storage_type == 'gcs':
         buf = df.to_csv(None, encoding='utf-8', **kwargs)
         bkt = _get_gcs_bucket(settings.storage_option['bucket_name'])
-        bkt.blob(path, chunk_size=1048576000).upload_from_string(buf, content_type='text/csv')
+        bkt.blob(path, storage_class=storage_class, chunk_size=1048576000).upload_from_string(buf, content_type='text/csv')
     else:
         raise ValueError('invalid storage_type')
 


### PR DESCRIPTION
pd_to_csvでstrage_typeがGCSの場合、アップロードするオブジェクトのストレージクラスを選べるようにした。（デフォルトはNone。アップロード先のバケットの設定に準じる。）